### PR TITLE
Feature/domain search for aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "webkult/laravel-smtp-mailing",
-  "description": "This package allows you to integrate an API to your Project to send Mails via FROM Parameter with diffrent SMTP Accounts change via FROM",
+  "description": "This package allows you to integrate an API to your Project to send Mails via FROM Parameter with different SMTP Accounts change via FROM",
   "type": "library",
   "license": "GPL-3.0-or-later",
   "autoload": {

--- a/config/laravel-smtp-mailing.php
+++ b/config/laravel-smtp-mailing.php
@@ -15,5 +15,5 @@ return [
     ],
 
     'default_from' => 'my@smtp-mail-config-in.database',
-    'enable_like_query_for_alias' => false,
+    'enable_domain_search' => false,
 ];

--- a/config/laravel-smtp-mailing.php
+++ b/config/laravel-smtp-mailing.php
@@ -14,5 +14,6 @@ return [
         'mail_dispatch_service' => \Webkult\LaravelSmtpMailing\Services\MailDispatchService::class,
     ],
 
-    'default_from' => 'my@smtp-mail-config-in.database'
+    'default_from' => 'my@smtp-mail-config-in.database',
+    'enable_like_query_for_alias' => false,
 ];

--- a/src/Services/MailDispatchService.php
+++ b/src/Services/MailDispatchService.php
@@ -51,11 +51,12 @@ class MailDispatchService
      */
     public function getSmtpCredentials(string $fromEmail)
     {
-        $alias = $this->smtpAccountAliasModel::where('from_email', $fromEmail)
-            ->when(
-                config('laravel-smtp-mailing.enable_like_query_for_alias'),
-                fn($query) => $query->orWhere('from_email', 'like', "%{$fromEmail}%")
-            )->first();
+        $alias = $this->smtpAccountAliasModel::where('from_email', $fromEmail)->first();
+
+        if (!$alias && config('laravel-smtp-mailing.enable_domain_search')) {
+            $domain = ltrim(strrchr($fromEmail, '@'), '@');
+            $alias = $this->smtpAccountAliasModel::where('from_email', $domain)->first();
+        }
 
         if (!$alias) {
             $alias = $this->smtpAccountAliasModel::where('from_email', config('laravel-smtp-mailing.default_from'))

--- a/src/Services/MailDispatchService.php
+++ b/src/Services/MailDispatchService.php
@@ -51,7 +51,11 @@ class MailDispatchService
      */
     public function getSmtpCredentials(string $fromEmail)
     {
-        $alias = $this->smtpAccountAliasModel::where('from_email', $fromEmail)->first();
+        $alias = $this->smtpAccountAliasModel::where('from_email', $fromEmail)
+            ->when(
+                config('laravel-smtp-mailing.enable_like_query_for_alias'),
+                fn($query) => $query->orWhere('from_email', 'like', "%{$fromEmail}%")
+            )->first();
 
         if (!$alias) {
             $alias = $this->smtpAccountAliasModel::where('from_email', config('laravel-smtp-mailing.default_from'))

--- a/src/Services/MailDispatchService.php
+++ b/src/Services/MailDispatchService.php
@@ -51,10 +51,12 @@ class MailDispatchService
      */
     public function getSmtpCredentials(string $fromEmail)
     {
-        $alias = $this->smtpAccountAliasModel::where('from_email', $fromEmail)->orWhere(
-            'from_email',
-            config('laravel-smtp-mailing.default_from')
-        )->first();
+        $alias = $this->smtpAccountAliasModel::where('from_email', $fromEmail)->first();
+
+        if (!$alias) {
+            $alias = $this->smtpAccountAliasModel::where('from_email', config('laravel-smtp-mailing.default_from'))
+                ->first();
+        }
 
         if (!$alias) {
             throw new SmtpAliasNotFoundException("No SMTP alias found for {$fromEmail}");

--- a/tests/Unit/GetSmtpCredentialsTest.php
+++ b/tests/Unit/GetSmtpCredentialsTest.php
@@ -13,7 +13,7 @@ uses(RefreshDatabase::class);
 
 class GetSmtpCredentialsTest extends TestCase
 {
-    public function test_throws_exception_when_no_alias_exists()
+    public function test_throws_exception_when_no_alias_exists(): void
     {
         $this->expectException(SmtpAliasNotFoundException::class);
 
@@ -125,7 +125,7 @@ class GetSmtpCredentialsTest extends TestCase
         $this->assertNotEquals('smtp.default.com', $result->host);
     }
 
-    public function test_dont_find_alias_by_like_if_like_query_config_disabled()
+    public function test_dont_find_alias_by_like_if_like_query_config_disabled(): void
     {
         $smtp = SmtpCredential::create([
             'host' => 'smtp.example.com',
@@ -146,7 +146,8 @@ class GetSmtpCredentialsTest extends TestCase
 
         app(MailDispatchService::class)->getSmtpCredentials('@example.com');
     }
-    public function test_returns_alias_found_by_like_if_like_query_config_enabled()
+
+    public function test_returns_alias_found_by_like_if_like_query_config_enabled(): void
     {
         $smtp = SmtpCredential::create([
             'host' => 'smtp.example.com',

--- a/tests/Unit/GetSmtpCredentialsTest.php
+++ b/tests/Unit/GetSmtpCredentialsTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Webkult\LaravelSmtpMailing\Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Webkult\LaravelSmtpMailing\Exceptions\SmtpAliasNotFoundException;
+use Webkult\LaravelSmtpMailing\Models\SmtpAccountAlias;
+use Webkult\LaravelSmtpMailing\Models\SmtpCredential;
+use Webkult\LaravelSmtpMailing\Services\MailDispatchService;
+use Webkult\LaravelSmtpMailing\Tests\TestCase;
+
+uses(RefreshDatabase::class);
+
+class GetSmtpCredentialsTest extends TestCase
+{
+    public function test_throws_exception_when_no_alias_exists()
+    {
+        $this->expectException(SmtpAliasNotFoundException::class);
+
+        app(MailDispatchService::class)->getSmtpCredentials('noreply@example.com');
+    }
+
+    public function test_throws_exception_when_alias_not_found_and_no_default_set(): void
+    {
+        $smtp = SmtpCredential::create([
+            'host' => 'smtp.example.com',
+            'port' => 587,
+            'encryption' => 'tls',
+            'username' => 'noreply@example.com',
+            'password' => encrypt('secret'),
+        ]);
+
+        SmtpAccountAlias::create([
+            'from_email' => 'noreply@example.com',
+            'smtp_credential_id' => $smtp->id,
+        ]);
+
+        $this->expectException(SmtpAliasNotFoundException::class);
+
+        app(MailDispatchService::class)->getSmtpCredentials('test@example.com');
+    }
+
+    public function test_returns_correct_credentials_if_alias_is_found(): void
+    {
+        $smtp = SmtpCredential::create([
+            'host' => 'smtp.example.com',
+            'port' => 587,
+            'encryption' => 'tls',
+            'username' => 'noreply@example.com',
+            'password' => encrypt('secret'),
+        ]);
+
+        SmtpAccountAlias::create([
+            'from_email' => 'noreply@example.com',
+            'smtp_credential_id' => $smtp->id,
+        ]);
+
+        $result = app(MailDispatchService::class)->getSmtpCredentials('noreply@example.com');
+
+        $this->assertInstanceOf(SmtpCredential::class, $result);
+        $this->assertEquals($smtp->id, $result->id);
+        $this->assertEquals('smtp.example.com', $result->host);
+    }
+
+    public function test_returns_default_credentials_if_alias_is_not_found(): void
+    {
+        $defaultSmtp = SmtpCredential::create([
+            'host' => 'smtp.example.com',
+            'port' => 587,
+            'encryption' => 'tls',
+            'username' => 'default@example.com',
+            'password' => encrypt('secret'),
+        ]);
+
+        SmtpAccountAlias::create([
+            'from_email' => 'default@example.com',
+            'smtp_credential_id' => $defaultSmtp->id,
+        ]);
+
+        config(['laravel-smtp-mailing.default_from' => 'default@example.com']);
+
+        $result = app(MailDispatchService::class)->getSmtpCredentials('default@example.com');
+
+        $this->assertInstanceOf(SmtpCredential::class, $result);
+        $this->assertEquals($defaultSmtp->id, $result->id);
+        $this->assertEquals('smtp.example.com', $result->host);
+    }
+
+    public function test_dont_returns_default_credentials_if_alias_is_found(): void
+    {
+        $defaultSmtp = SmtpCredential::create([
+            'host' => 'smtp.default.com',
+            'port' => 587,
+            'encryption' => 'tls',
+            'username' => 'default@example.com',
+            'password' => encrypt('secret'),
+        ]);
+
+        SmtpAccountAlias::create([
+            'from_email' => 'default@example.com',
+            'smtp_credential_id' => $defaultSmtp->id,
+        ]);
+
+        config(['laravel-smtp-mailing.default_from' => 'default@example.com']);
+
+        $smtp = SmtpCredential::create([
+            'host' => 'smtp.example.com',
+            'port' => 587,
+            'encryption' => 'tls',
+            'username' => 'noreply@example.com',
+            'password' => encrypt('secret'),
+        ]);
+
+        SmtpAccountAlias::create([
+            'from_email' => 'noreply@example.com',
+            'smtp_credential_id' => $smtp->id,
+        ]);
+
+        $result = app(MailDispatchService::class)->getSmtpCredentials('noreply@example.com');
+
+        $this->assertInstanceOf(SmtpCredential::class, $result);
+        $this->assertEquals($smtp->id, $result->id);
+        $this->assertEquals('smtp.example.com', $result->host);
+        $this->assertNotEquals($defaultSmtp->id, $result->id);
+        $this->assertNotEquals('smtp.default.com', $result->host);
+    }
+}

--- a/tests/Unit/GetSmtpCredentialsTest.php
+++ b/tests/Unit/GetSmtpCredentialsTest.php
@@ -125,7 +125,7 @@ class GetSmtpCredentialsTest extends TestCase
         $this->assertNotEquals('smtp.default.com', $result->host);
     }
 
-    public function test_dont_find_alias_by_like_if_like_query_config_disabled(): void
+    public function test_dont_find_domain_alias_if_domain_search_config_disabled(): void
     {
         $smtp = SmtpCredential::create([
             'host' => 'smtp.example.com',
@@ -136,18 +136,18 @@ class GetSmtpCredentialsTest extends TestCase
         ]);
 
         SmtpAccountAlias::create([
-            'from_email' => 'noreply@example.com',
+            'from_email' => 'example.com',
             'smtp_credential_id' => $smtp->id,
         ]);
 
-        config(['laravel-smtp-mailing.enable_like_query_for_alias' => false]);
+        config(['laravel-smtp-mailing.enable_domain_search' => false]);
 
         $this->expectException(SmtpAliasNotFoundException::class);
 
-        app(MailDispatchService::class)->getSmtpCredentials('@example.com');
+        app(MailDispatchService::class)->getSmtpCredentials('noreply@example.com');
     }
 
-    public function test_returns_alias_found_by_like_if_like_query_config_enabled(): void
+    public function test_returns_domain_alias_if_domain_search_config_enabled(): void
     {
         $smtp = SmtpCredential::create([
             'host' => 'smtp.example.com',
@@ -158,13 +158,13 @@ class GetSmtpCredentialsTest extends TestCase
         ]);
 
         SmtpAccountAlias::create([
-            'from_email' => 'noreply@example.com',
+            'from_email' => 'example.com',
             'smtp_credential_id' => $smtp->id,
         ]);
 
-        config(['laravel-smtp-mailing.enable_like_query_for_alias' => true]);
+        config(['laravel-smtp-mailing.enable_domain_search' => true]);
 
-        $result = app(MailDispatchService::class)->getSmtpCredentials('@example.com');
+        $result = app(MailDispatchService::class)->getSmtpCredentials('noreply@example.com');
 
         $this->assertInstanceOf(SmtpCredential::class, $result);
         $this->assertEquals($smtp->id, $result->id);


### PR DESCRIPTION
`getSmtpCredentials` function of `MailDispatchService` is altered in the following way:

- allow searching for domain aliases, if new config parameter `enable_domain_search` is set to true
- doesn't return default alias, when alias for given `$fromEmail` can be found